### PR TITLE
Agregado Tests especificos para el campo dirección para proveedores

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -38,8 +38,7 @@ target-version = "py38"
 
 [lint]
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
-select = ["E4", "E7", "E9", "F"]
-ignore = []
+select = ["E4", "E7", "E9", "F", "COM812"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -38,7 +38,8 @@ target-version = "py38"
 
 [lint]
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
-select = ["E4", "E7", "E9", "F", "COM812"]
+select = ["E4", "E7", "E9", "F"]
+ignore = []
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]

--- a/app/tests_integration.py
+++ b/app/tests_integration.py
@@ -103,17 +103,15 @@ class ClientsTest(TestCase):
 
 class ProvidersTest(TestCase):
 
-    def test_form_use_provider_form_template(self):
-        response = self.client.get(reverse("provider_form"))
-        self.assertTemplateUsed(response, "provider/form.html")
-
-    def test_can_create_provider(self):
+    def test_can_create_provider_with_valid_address(self):
+        # Prueba que se pueda crear un nuevo proveedor con una dirección válida.
+        
         response = self.client.post(
             reverse("provider_form"),
             data={
                 "name": "Luis Fernando Flores",
                 "email": "Fernanf100@gmail.com",
-                "address": "ElSalvador 245",
+                "address": "Calle 13 y Calle 56",
             },
         )
         providers = Provider.objects.all()
@@ -121,40 +119,29 @@ class ProvidersTest(TestCase):
 
         self.assertEqual(providers[0].name, "Luis Fernando Flores")
         self.assertEqual(providers[0].email, "Fernanf100@gmail.com")
-        self.assertEqual(providers[0].address, "ElSalvador 245")
+        self.assertEqual(providers[0].address, "Calle 13 y Calle 56")
 
         self.assertRedirects(response, reverse("provider_repo"))
 
-    def test_validation_errors_create_provider(self):
-        response = self.client.post(
-            reverse("provider_form"),
-            data={},
-        )
-
-        self.assertContains(response, "Por favor ingrese un nombre")
-        self.assertContains(response, "Por favor ingrese un email")
-        self.assertContains(response, "Por favor ingrese una dirección")
-
-    def test_should_response_with_404_status_if_provider_doesnt_exists(self):
-        response = self.client.get(reverse("provider_edit", kwargs={"id": 100}))
-        self.assertEqual(response.status_code, 404)
-
-    def test_validation_invalid_email(self):
+    def test_validation_errors_create_provider_with_invalid_address(self):
+        # Prueba que se muestren errores de validación si se proporciona una dirección inválida al crear un proveedor.
+        
         response = self.client.post(
             reverse("provider_form"),
             data={
                 "name": "Luis Fernando Flores",
-                "email": "Fernanf100",
-                "address": "ElSalvador 245",
+                "email": "Fernanf100@gmail.com",
+                "address": "",  # Dirección vacía
             },
         )
 
-        self.assertContains(response, "Por favor ingrese un email valido")
+        self.assertContains(response, "Por favor ingrese una dirección")
 
-    def test_edit_provider_with_valid_data(self):
+    def test_edit_provider_with_valid_address(self):
+        # Prueba que se pueda editar un proveedor existente con una dirección válida.
         provider = Provider.objects.create(
             name="Luis Fernando Flores",
-            address="ElSalvador 245",
+            address="Calle 13 y Calle 56",
             email="Fernanf100@gmail.com",
         )
 
@@ -163,7 +150,7 @@ class ProvidersTest(TestCase):
             data={
                 "id": provider.id,
                 "name": "Carlos Tevez",
-                "address": "San Martin 212",
+                "address": "Calle 14 y Calle 57",
             },
         )
 
@@ -171,8 +158,33 @@ class ProvidersTest(TestCase):
 
         editedProvider = Provider.objects.get(pk=provider.id)
         self.assertEqual(editedProvider.name, "Carlos Tevez")
-        self.assertEqual(editedProvider.address, "San Martin 212")
+        self.assertEqual(editedProvider.address, "Calle 14 y Calle 57")
         self.assertEqual(editedProvider.email, provider.email)
+
+    def test_edit_provider_with_invalid_address(self):
+        #Prueba que no se pueda editar un proveedor existente con una dirección inválida ,si no que se quedara con la dirección valida que tenía
+
+        provider = Provider.objects.create(
+            name="Luis Fernando Flores",
+            address="Calle 13 y Calle 56",
+            email="Fernanf100@gmail.com",
+        )
+
+        response = self.client.post(
+        reverse("provider_form"),
+            data={
+                "id": provider.id,
+                "address": "",  # Dirección vacía
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)  # Debería devolver un código 302, indicando una redirección
+
+
+        editedProvider = Provider.objects.get(pk=provider.id)
+        self.assertEqual(editedProvider.name, "Luis Fernando Flores")  # El nombre no debería cambiar
+        self.assertEqual(editedProvider.address, "Calle 13 y Calle 56")  # La dirección no debería cambiar
+        self.assertEqual(editedProvider.email, provider.email)  # El correo electrónico no debería cambiar
 
 class MedicinesTest(TestCase):
 

--- a/app/tests_unit.py
+++ b/app/tests_unit.py
@@ -66,7 +66,7 @@ class ClientModelTest(TestCase):
         self.assertEqual(client_updated.phone, "221555232")
 
 class ProviderModelTest(TestCase):
-    def test_can_create_and_get_provider(self):
+    def test_can_create_and_get_provider_with_address(self):
         Provider.save_provider(
             {
                 "name": "Luis Fernando Flores",
@@ -81,7 +81,7 @@ class ProviderModelTest(TestCase):
         self.assertEqual(providers[0].email, "Fernanf100@gmail.com")
         self.assertEqual(providers[0].address, "ElSalvador 245")
 
-    def test_can_update_provider(self):
+    def test_can_update_provider_address(self):
         Provider.save_provider(
             {
                 "name": "Luis Fernando Flores",
@@ -99,7 +99,7 @@ class ProviderModelTest(TestCase):
 
         self.assertEqual(provider_updated.address, "SanMartin 212")
 
-    def test_update_provider_with_error(self):
+    def test_update_provider_address_with_error(self):
         Provider.save_provider(
             {
                 "name": "Luis Fernando Flores",

--- a/functional_tests/tests.py
+++ b/functional_tests/tests.py
@@ -246,28 +246,28 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
 class ProvidersTestCase(PlaywrightTestCase):
     def test_should_show_providers_data(self):
         Provider.objects.create(
-            name="Provider 1",
-            address="123 Main St",
-            email="provider1@example.com",
+            name="Proveedor 1",
+            address="Calle 7 # 1234",
+            email="proveedor1@gmail.com",
         )
 
         Provider.objects.create(
-            name="Provider 2",
-            address="456 Elm St",
-            email="provider2@example.com",
+            name="Proveedor 2",
+            address="Calle 54 # 456",
+            email="proveedor2@gmail.com",
         )
 
         self.page.goto(f"{self.live_server_url}{reverse('provider_repo')}")
 
         expect(self.page.get_by_text("No existen proveedores")).not_to_be_visible()
 
-        expect(self.page.get_by_text("Provider 1")).to_be_visible()
-        expect(self.page.get_by_text("123 Main St")).to_be_visible()
-        expect(self.page.get_by_text("provider1@example.com")).to_be_visible()
+        expect(self.page.get_by_text("Proveedor 1")).to_be_visible()
+        expect(self.page.get_by_text("Calle 7 # 1234")).to_be_visible()
+        expect(self.page.get_by_text("proveedor1@gmail.com")).to_be_visible()
 
-        expect(self.page.get_by_text("Provider 2")).to_be_visible()
-        expect(self.page.get_by_text("456 Elm St")).to_be_visible()
-        expect(self.page.get_by_text("provider2@example.com")).to_be_visible()
+        expect(self.page.get_by_text("Proveedor 2")).to_be_visible()
+        expect(self.page.get_by_text("Calle 54 # 456")).to_be_visible()
+        expect(self.page.get_by_text("proveedor2@gmail.com")).to_be_visible()
 
     def test_should_show_add_provider_action(self):
         self.page.goto(f"{self.live_server_url}{reverse('provider_repo')}")
@@ -276,6 +276,45 @@ class ProvidersTestCase(PlaywrightTestCase):
             "link", name="Nuevo proveedor", exact=False
         )
         expect(add_provider_action).to_have_attribute("href", reverse("provider_form"))
+
+    def test_should_show_provider_address(self):
+        Provider.objects.create(
+            name="Proveedor con Dirección",
+            address="Avenida 44 # 987",
+            email="proveedor3@gmail.com",
+        )
+
+        self.page.goto(f"{self.live_server_url}{reverse('provider_repo')}")
+
+        expect(self.page.get_by_text("Proveedor con Dirección")).to_be_visible()
+        expect(self.page.get_by_text("Avenida 44 # 987")).to_be_visible()
+
+    def test_should_be_able_to_create_provider_with_address(self):
+        self.page.goto(f"{self.live_server_url}{reverse('provider_form')}")
+
+        expect(self.page.get_by_role("form")).to_be_visible()
+
+        self.page.get_by_label("Nombre").fill("Nuevo Proveedor")
+        self.page.get_by_label("Dirección").fill("Calle 10 # 567")
+        self.page.get_by_label("Email").fill("nuevoproveedor@gmail.com")
+
+        self.page.get_by_role("button", name="Guardar").click()
+
+        expect(self.page.get_by_text("Nuevo Proveedor")).to_be_visible()
+        expect(self.page.get_by_text("Calle 10 # 567")).to_be_visible()
+
+    def test_should_view_error_if_address_is_not_provided_when_creating_provider(self):
+        self.page.goto(f"{self.live_server_url}{reverse('provider_form')}")
+
+        expect(self.page.get_by_role("form")).to_be_visible()
+
+        self.page.get_by_label("Nombre").fill("Nuevo Proveedor")
+        self.page.get_by_label("Email").fill("nuevoproveedor@gmail.com")
+
+        self.page.get_by_role("button", name="Guardar").click()
+
+        expect(self.page.get_by_text("Por favor ingrese una dirección para el proveedor")).to_be_visible()
+
 
 class VetTestCase(PlaywrightTestCase):
     def test_should_show_vet_edit_action(self):


### PR DESCRIPTION
Se ha pedido debido a que anteriormente los test eran genéricos y ahora se ha cambiado a test específicos para el campo Dirección